### PR TITLE
Configurable elasticsearch URL

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -13,7 +13,11 @@ var App = Em.Application.create({
 
   elasticsearch_url: function() {
     var location = window.location
-    return (/_plugin/.test(location.href.toString())) ? location.protocol + "//" + location.host : "http://localhost:9200"
+    var args = location.search.substring(1).split("&").reduce(function(r, p) {
+        r[decodeURIComponent(p.split("=")[0])] = decodeURIComponent(p.split("=")[1]); return r;
+    }, {});
+    var base_uri = args["base_uri"] || "http://localhost:9200";
+    return (/_plugin/.test(location.href.toString())) ? location.protocol + "//" + location.host : base_uri
   }(),
 
   refresh_intervals : Ember.ArrayController.create({


### PR DESCRIPTION
I've added the ability to use a parameter in the URL to specify the elasticsearch url. Ex : index.html?base_uri=http://es_server:es_port

It can be used for bookmarking, creating hyperlinks from a monitoring application,...
