### PR TITLE
Allow node filtering via URL Hash

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,10 @@ var App = Em.Application.create({
     return (/_plugin/.test(location.href.toString())) ? location.protocol + "//" + location.host : "http://localhost:9200"
   }(),
 
+  elasticsearch_node_filter: function () {
+    return location.hash.substring(1);
+  }(),
+
   refresh_intervals : Ember.ArrayController.create({
     content: [
       {label: '1 sec',  value: 1000},
@@ -152,8 +156,8 @@ App.nodes = Ember.ArrayController.create({
     };
 
     App.set("refreshing", true)
-    $.getJSON(App.elasticsearch_url+"/_cluster/nodes?jvm", __load_nodes_info);
-    $.getJSON(App.elasticsearch_url+"/_cluster/nodes/stats?indices&os&process&jvm", __load_nodes_stats);
+    $.getJSON(App.elasticsearch_url+"/_cluster/nodes/" + App.elasticsearch_node_filter + "?jvm", __load_nodes_info);
+    $.getJSON(App.elasticsearch_url+"/_nodes/" + App.elasticsearch_node_filter + "stats?indices&os&process&jvm", __load_nodes_stats);
   }
 });
 

--- a/js/libs/cubism.elasticsearch.js
+++ b/js/libs/cubism.elasticsearch.js
@@ -209,7 +209,7 @@ cubism.elasticsearch = function(context, options, callback) {
   // Load information about ElasticSearch nodes from the Nodes Info API
   // [http://www.elasticsearch.org/guide/reference/api/admin-cluster-nodes-info.html]
   //
-  d3.json(options.host + "/_cluster/nodes", function(cluster) {
+  d3.json(options.host + "/_nodes/" + location.hash.substring(1), function(cluster) {
     source.cluster   = cluster
     source.node_names = d3.keys(cluster.nodes)
 


### PR DESCRIPTION
I had weird issues when I tried to add a filter text field so I implemented it via a hash. The use case for us was we use have client nodes on our app servers and all the client node stats are just clutter.

We'd access it with `index.html#master:true` for example.

I'm not really a JS dev and have zero experience with Ember so this is what I managed to hack up in a few minutes.
