### PR TITLE
Detect when paramedic is run from /foo/_plugin/paramedic/, and set elasticsearch_url accordingly.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -12,9 +12,9 @@ var App = Em.Application.create({
   },
 
   elasticsearch_url: function() {
-    var location = window.location
+    var href = window.location.href.toString()
     
-    return (/_plugin/.test(location.href.toString())) ? location.href.substring(0, location.href.indexOf('/_plugin/') : "http://localhost:9200"
+    return (/_plugin/.test(href) ? href.substring(0, href.indexOf('/_plugin/') : "http://localhost:9200"
   }(),
 
   refresh_intervals : Ember.ArrayController.create({


### PR DESCRIPTION
I have elasticsearch running behind a proxy for security reasons. In my setup, I access elasticsearch at http://server:port/foo/, and paramedic at http://server:port/foo/_plugin/paramedic/. With these small changes, paramedic handles my use case out of the box.
