### PR TITLE
Fixes syntax error in elasticsearch_url

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ var App = Em.Application.create({
   elasticsearch_url: function() {
     var href = window.location.href.toString()
     
-    return (/_plugin/.test(href) ? href.substring(0, href.indexOf('/_plugin/') : "http://localhost:9200"
+    return /_plugin/.test(href) ? href.substring(0, href.indexOf('/_plugin/')) : "http://localhost:9200"
   }(),
 
   refresh_intervals : Ember.ArrayController.create({


### PR DESCRIPTION
Found I was getting an error in my javascript console.  On line 17 in app.js.
